### PR TITLE
Add layer-based anomaly prediction support

### DIFF
--- a/3D.sh
+++ b/3D.sh
@@ -49,13 +49,13 @@ d_ff=256
 comment='TimeLLM-3D'
 
 python -u run_main_V1.py \
-  --task_name anomaly_classification \
+  --task_name layer_prediction \
   --is_training 1 \
   --root_path ./dataset/温度原因-1/ \
   --data_path all.csv \
   --model_id 3D_512_96 \
   --model $model_name \
-  --data 3D \
+  --data 3DLP \
   --features M \
   --freq s \
   --seq_len 256 \

--- a/data_provider/data_factory.py
+++ b/data_provider/data_factory.py
@@ -1,4 +1,11 @@
-from data_provider.data_loader import Dataset_ETT_hour, Dataset_ETT_minute, Dataset_Custom, Dataset_M4, Dataset_3D
+from data_provider.data_loader import (
+    Dataset_ETT_hour,
+    Dataset_ETT_minute,
+    Dataset_Custom,
+    Dataset_M4,
+    Dataset_3D,
+    Dataset_3D_LayerPred,
+)
 from torch.utils.data import DataLoader
 from torch.nn.utils.rnn import pad_sequence
 
@@ -25,7 +32,8 @@ data_dict = {
     'Weather': Dataset_Custom,
     'm4': Dataset_M4,
     'retraction': Dataset_Custom,
-    '3D': Dataset_3D  # 标记需要特殊处理的数据集
+    '3D': Dataset_3D,  # 默认3D数据集
+    '3DLP': Dataset_3D_LayerPred  # 基于层的预测数据集
 }
 
 def data_provider(args, flag):
@@ -35,7 +43,8 @@ def data_provider(args, flag):
 
     # 动态配置collate_fn
     collate_fn = None
-    if args.data == '3D':  # 仅为3D数据集指定自定义collate
+    if args.data in ['3D', '3DLP']:
+        # 3D 系列数据集需要自定义collate
         collate_fn = custom_collate_3d
 
     # 通用参数配置
@@ -61,7 +70,7 @@ def data_provider(args, flag):
             seasonal_patterns=args.seasonal_patterns
         )
         common_params['drop_last'] = False  # M4特殊处理
-    elif args.data == '3D':
+    elif args.data in ['3D', '3DLP']:
         # 3D数据集需要传递额外参数
         data_set = Data(
             root_path=args.root_path,


### PR DESCRIPTION
## Summary
- create `Dataset_3D_LayerPred` for predicting the next layer's anomaly label
- register new dataset key `3DLP`
- allow `layer_prediction` as a task name in `run_main_V1.py`
- update `3D.sh` to run layer-based prediction
- fix missing newline in `data_provider/data_factory.py`
- implement `__init__` in `Dataset_3D_LayerPred`

## Testing
- `python - <<'PY'
from data_provider.data_factory import data_provider
import argparse
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684bd5d3776c832db1e23697dfdfe9d2